### PR TITLE
Always output instructions on batch scan.

### DIFF
--- a/scanline/AppController.m
+++ b/scanline/AppController.m
@@ -293,7 +293,7 @@
     DDLogVerbose( @"scannerDevice: \n%@\ndidCompleteScanWithError: \n%@\n", scanner, error );
 
     if ([configuration isBatch]) {
-        DDLogVerbose(@"Press RETURN to scan next page or S to stop");
+        DDLogInfo(@"Press RETURN to scan next page or S to stop");
         int userInput;
         userInput = getchar();
         if (userInput != 's' && userInput != 'S')


### PR DESCRIPTION
Instructions when batch scanning were only output when using verbose mode. But the verbose mode is really verbose. Users that didn't write the program could have trouble knowing what to do when the first page or the whole document is done when not outputting this help. Since there is no built in help or man page.
